### PR TITLE
Problem: Cannot use typescript in components

### DIFF
--- a/src/components/modals/AddProblem.svelte
+++ b/src/components/modals/AddProblem.svelte
@@ -28,8 +28,8 @@
   
     const profileData = writable(FUCKYOUVITE());
 
-    let formOpen = false;
-    let title_text = "";
+    let formOpen: boolean = false;
+    let title_text: string = "";
     let summary_text = "";
     let full_text = "";
     let formValidation = true;

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -7,13 +7,14 @@ const dev = process.argv.includes("dev");
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-  preprocess: [
-    optimizeImports(),
-    vitePreprocess(),
-    // preprocess({
-    // 	postcss: true
-    // })
-  ],
+  // preprocess: [
+  //   optimizeImports(),
+  //   vitePreprocess(),
+  //   // preprocess({
+  //   // 	postcss: true
+  //   // })
+  // ],
+  preprocess: [vitePreprocess(), optimizeImports()],
   kit: {
     adapter: adapter({
       fallback: "404.html",


### PR DESCRIPTION
Solution:
Changed order of preprocess plugin - placed the vitePreprocess first.

Further reading on how to use svelte with typescript [here](https://svelte.dev/docs/typescript#setup-using-sveltekit-or-vite)