### PR TITLE
Problem: Not clear how we find current state

### DIFF
--- a/src/components/views/Identity.svelte
+++ b/src/components/views/Identity.svelte
@@ -6,6 +6,31 @@
     import AddIdentity from "../modals/AddIdentity.svelte";
     import IdentityContext from "$lib/contexts/IdentityContext.svelte";
     import IdentityList from "$lib/components/identity/IdentityList.svelte";
+    import ndk from "$lib/stores/ndk";
+    import IdentityResource from "$lib/resources/IdentityResource";
+    import {getContext, onDestroy} from "svelte";
+    import {ignitionPubkey} from "$lib/settings";
+
+    const rocketMap = getContext('rocketMap')
+
+    // TODO: Rename this to profiles
+    const identities = $ndk.storeSubscribe(
+        {kinds: [0], authors: [ignitionPubkey]},
+        {closeOnEose: false},
+        IdentityResource
+    )
+
+    // subscribe to the rocketMap context
+    // we can use this to get list of participants as well
+    rocketMap.subscribe((entries) => {
+        entries.forEach((entry) => {
+            console.log({entry})
+        })
+    })
+
+    onDestroy(() => {
+        identities.unsubscribe()
+    })
 </script>
 
 <IdentityContext>
@@ -46,5 +71,5 @@
             <Profile profile={p.profile} num={p.index}/>
         {/each}
     </Row>
-    <IdentityList />
+    <IdentityList/>
 </IdentityContext>

--- a/src/lib/consensus/state.ts
+++ b/src/lib/consensus/state.ts
@@ -101,7 +101,6 @@ allEventKinds.subscribe((e) => {
 export const nostrocketParticipants = derived(consensusTipState, ($cts) => {
     let orderedList: Account[] = [];
     recursiveList(nostrocketIgnitionEvent, ignitionPubkey, $cts, orderedList);
-    console.log({orderedList})
     return orderedList;
 });
 
@@ -124,7 +123,7 @@ function recursiveList(
 
 nostrocketParticipants.subscribe((pkList) => {
     pkList.forEach((pk) => {
-        let user = $ndk_profiles.getUser({hexpubkey: pk});
+        let user = $ndk_profiles.getUser({hexpubkey: pk})
         user.fetchProfile().then((profile) => {
             if (user.profile) {
                 profiles.update((data) => {
@@ -159,6 +158,7 @@ export let validConsensusEvents = derived(allNostrocketEvents, ($vce) => {
     $vce = $vce.filter((event: NDKEvent) => {
         return labelledTag(event, "root", "e") == rootEventID;
     });
+
     $vce = $vce.filter((event: NDKEvent) => {
         return validate(event, get(consensusTipState));
     });
@@ -194,6 +194,7 @@ export function labelledTag(
 }
 
 validConsensusEvents.subscribe((x) => {
+    console.log('are we validating anything?')
     if (x[0]) {
         let request = labelledTag(x[0], "request", "e");
         if (request) {
@@ -211,7 +212,6 @@ validConsensusEvents.subscribe((x) => {
                 }
                 if (requestEvent) {
                     if (validate(requestEvent, current)) {
-                        console.log({current})
                         //todo use copy instead of reference (newstate is just a reference here) have to write a manual clone function for this
                         let [newstate, ok] = current.HandleStateChangeEvent(requestEvent);
                         if (ok) {
@@ -259,7 +259,8 @@ function processMempool(currentState: Nostrocket): Nostrocket {
         //todo clone not ref
         switch (e.kind) {
             case 30000: {
-              console.log('Identity', {e})
+                console.log('processing identity')
+                console.log({e})
                 let [n, success] = handleIdentityEvent(e, currentState);
                 if (success) {
                     currentState = n;

--- a/src/lib/contexts/AppStateContext.svelte
+++ b/src/lib/contexts/AppStateContext.svelte
@@ -11,25 +11,25 @@
     const _nostrocketTipState = new Nostrocket(JSON.stringify(''))
     const nostrocketTipState = writable<Nostrocket>(_nostrocketTipState)
 
-    const allNostrocketEventKindSub = $ndk.storeSubscribe<NDKEvent>(
-        {"#e": [rootEventID], kinds: allNostrocketEventKinds}, //"#e": [ignitionEvent] , authors: [ignitionPubkey] kinds: allNostrocketEventKinds, "#e": [mainnetRoot]
-        {closeOnEose: false}
-    )
+    // const allNostrocketEventKindSub = $ndk.storeSubscribe<NDKEvent>(
+    //     {"#e": [rootEventID], kinds: allNostrocketEventKinds}, //"#e": [ignitionEvent] , authors: [ignitionPubkey] kinds: allNostrocketEventKinds, "#e": [mainnetRoot]
+    //     {closeOnEose: false}
+    // )
 
-    export const allEventKinds = $ndk.storeSubscribe<NDKEvent>(
-        {kinds: allNostrocketEventKinds}, //"#e": [ignitionEvent] , authors: [ignitionPubkey] kinds: allNostrocketEventKinds, "#e": [mainnetRoot]
-        {closeOnEose: false}
-    );
+    // export const allEventKinds = $ndk.storeSubscribe<NDKEvent>(
+    //     {kinds: allNostrocketEventKinds}, //"#e": [ignitionEvent] , authors: [ignitionPubkey] kinds: allNostrocketEventKinds, "#e": [mainnetRoot]
+    //     {closeOnEose: false}
+    // );
 
-    export const allNostrocketEvents = derived(allNostrocketEventKindSub, ($allNostrocketEventKindSub) => {
-        $allNostrocketEventKindSub.filter((e) => {
-            if (e.kind) {
-                return allNostrocketEventKinds.includes(e.kind);
-            }
-            return false;
-        });
-        return $allNostrocketEventKindSub;
-    });
+    // export const allNostrocketEvents = derived(allNostrocketEventKindSub, ($allNostrocketEventKindSub) => {
+    //     $allNostrocketEventKindSub.filter((e) => {
+    //         if (e.kind) {
+    //             return allNostrocketEventKinds.includes(e.kind);
+    //         }
+    //         return false;
+    //     });
+    //     return $allNostrocketEventKindSub;
+    // });
 
     setContext('consensusTipState', nostrocketTipState)
 </script>

--- a/src/lib/contexts/NDKContext.svelte
+++ b/src/lib/contexts/NDKContext.svelte
@@ -1,20 +1,86 @@
 <script lang="ts">
-    import NDKSvelte from "@nostr-dev-kit/ndk-svelte";
-    import {defaultRelays} from "$lib/settings";
-    import {writable} from "svelte/store";
-    import {onMount, setContext} from "svelte";
+    import {ignitionPubkey, rootEventID} from "$lib/settings";
+    import NostrocketEvent from "$lib/events/NostrocketEvent";
+    import {onDestroy, onMount, setContext} from "svelte";
+    import ndk from "$lib/stores/ndk";
+    import type {Identity, Rocket, RocketID} from "$lib/types";
+    import {derived, writable} from "svelte/store";
+    import {identity, rocket} from "$lib/types";
+    import {allNostrocketEventKinds} from "$lib/kinds";
+    import {labelledTag} from "$lib/consensus/state";
 
-    const _ndk: NDKSvelte = new NDKSvelte({explicitRelayUrls: defaultRelays});
-    const ndk = writable<NDKSvelte>(_ndk);
-    setContext('ndk', ndk)
+    type IdentityList = Identity[]
+    type IdentityMap = Map<string, Identity>
+    type EventPool = Map<string, NostrocketEvent>
+    type RocketMap = Map<string, Rocket>
 
-    onMount(async () => {
-        try {
-            await $ndk.connect()
-            console.log('NDK connected...')
-        } catch (err) {
-            console.error(err)
+    const identityList = writable<IdentityList>([])
+    const identityMap = writable<IdentityMap>(new Map())
+    const eventsNotInState = writable<EventPool>(new Map()) // all state change requests that are potentially valid but not included in the current state.
+    const validatedEvents = writable<EventPool>(new Map())
+    const rocketMap = writable<RocketMap>(new Map())
+
+    // Subscribe to all events that have a e tag, pointing to the ignition event with label root.
+    const subscriptionOpts = {"#e": [rootEventID], kinds: [30000, 15172008, 15171031]}
+    const nostrocketEvents = $ndk.storeSubscribe<NostrocketEvent>(subscriptionOpts, {closeOnEose: false}, NostrocketEvent)
+
+    nostrocketEvents.subscribe((events) => {
+        events.forEach((nostrocketEvent: NostrocketEvent) => {
+            switch (nostrocketEvent.kind) {
+                case 30000:
+                    nostrocketEvent.getMatchingTags('d').forEach((ndkTag) => {
+                        if (ndkTag[1].length === 64) {
+                            const exisitingRocket = $rocketMap.get(ndkTag[1])
+
+                            if (exisitingRocket) {
+                                exisitingRocket.updateParticipants(nostrocketEvent)
+                                rocketMap.update((current) => {
+                                    current.delete(exisitingRocket.UID)
+                                    current.set(exisitingRocket.UID, exisitingRocket)
+                                    return current
+                                })
+                            }
+                        }
+                    })
+
+                    break;
+
+                case 15171031:
+                    nostrocketEvent.getMatchingTags('n').forEach((ndkTag) => {
+                        const newRocket = new rocket(undefined)
+                        newRocket.fromEvent(nostrocketEvent, ndkTag[1], undefined)
+                        rocketMap.update((current) => {
+                            current.set(newRocket.UID, newRocket)
+                            return current
+                        })
+                    })
+
+                    break;
+                default:
+                    console.log('Not yet implemented')
+            }
+        })
+    })
+
+    identityMap.subscribe(console.log)
+    eventsNotInState.subscribe((some) => console.log({some}))
+
+    setContext('rocketMap', rocketMap)
+
+    onMount(() => {
+        if (!($identityMap.get(ignitionPubkey))) {
+            identityMap.set((new Map()).set(ignitionPubkey, new identity({
+                Account: ignitionPubkey,
+                Name: "Ignition Account",
+                MaintainerBy: "1Humanityrvhus5mFWRRzuJjtAbjk2qwww",
+                Order: 0,
+                UniqueSovereignBy: "1Humanityrvhus5mFWRRzuJjtAbjk2qwww",
+            })))
         }
+    })
+
+    onDestroy(() => {
+        nostrocketEvents.unsubscribe()
     })
 </script>
 

--- a/src/lib/events/NostrocketEvent.ts
+++ b/src/lib/events/NostrocketEvent.ts
@@ -1,0 +1,26 @@
+import NDK, {NDKEvent, type NostrEvent} from "@nostr-dev-kit/ndk";
+import createEventpool from "$lib/stores/mempool";
+import {mempool} from "$lib/consensus/state";
+
+const memPool = createEventpool()
+const eventsInState = createEventpool()
+
+export default class NostrocketEvent extends NDKEvent {
+    constructor(ndk: NDK, event: NostrEvent) {
+        super(ndk, event);
+    }
+
+    static from(event: NDKEvent): NostrocketEvent {
+        // const rawEvent = event.rawEvent()
+        //
+        // if (!eventsInState.fetch(rawEvent.id!) && !memPool.fetch(rawEvent.id!)) {
+        //     memPool.push(event);
+        // }
+
+        if (event.kind === 30000) {
+            console.log(event.pubkey)
+        }
+
+        return new NostrocketEvent(event.ndk!, event.rawEvent());
+    }
+}

--- a/src/lib/resources/IdentityResource.ts
+++ b/src/lib/resources/IdentityResource.ts
@@ -1,0 +1,12 @@
+import NDK, {NDKEvent, NDKHighlight, type NostrEvent} from "@nostr-dev-kit/ndk";
+
+export default class IdentityResource extends NDKEvent {
+    constructor(ndk: NDK, event: NostrEvent) {
+        super(ndk, event);
+    }
+
+    static from(event: NDKEvent): IdentityResource {
+        console.log('Kind: ', event.rawEvent())
+        return new IdentityResource(event.ndk!, event.rawEvent());
+    }
+}

--- a/src/lib/stores/mempool.ts
+++ b/src/lib/stores/mempool.ts
@@ -9,7 +9,7 @@ import { labelledTag } from "$lib/consensus/state";
 import type { NDKEvent } from "@nostr-dev-kit/ndk";
 import { get, writable } from "svelte/store";
 
-export default function createEventpool(notstrict: boolean | undefined) {
+export default function createEventpool(notstrict?: boolean | undefined) {
   const raw = writable<Map<string, NDKEvent>>(new Map<string, NDKEvent>());
   const { subscribe, set, update } = raw;
   return {

--- a/src/lib/stores/ndk.ts
+++ b/src/lib/stores/ndk.ts
@@ -1,0 +1,15 @@
+import NDKSvelte from "@nostr-dev-kit/ndk-svelte";
+import {defaultRelays, profileRelays} from "$lib/settings";
+import {writable} from "svelte/store";
+import type {NDKEvent} from "@nostr-dev-kit/ndk";
+
+const _ndk = new NDKSvelte({explicitRelayUrls: [...defaultRelays, ...profileRelays]})
+
+try {
+    await _ndk.connect()
+    console.log('NDK connected here...')
+} catch (e) {
+    console.error(e)
+}
+
+export default writable<NDKSvelte>(_ndk)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -306,6 +306,7 @@ export class Nostrocket implements Nostrocket {
     this.Rockets = [];
     this.Problems = new Map();
     let j: any;
+
     if (!this.IdentityMap.get(ignitionPubkey)) {
       this.IdentityMap.set(
         ignitionPubkey,
@@ -318,8 +319,10 @@ export class Nostrocket implements Nostrocket {
         })
       );
     }
+
     try {
       j = JSON.parse(input);
+      console.log({j})
       try {
         if (j.HEAD) {
           this.LastConsensusEvent = j.HEAD;
@@ -359,7 +362,7 @@ export class Nostrocket implements Nostrocket {
   }
 }
 
-class rocket implements Rocket {
+export class rocket implements Rocket {
   UID: string;
   Name: string;
   CreatedBy: string;
@@ -431,7 +434,7 @@ class rocket implements Rocket {
   }
 }
 
-class identity implements Identity {
+export class identity implements Identity {
   Account: Account;
   CharacterVouchedForBy: Array<string>;
   LatestKind0: NDKEvent;


### PR DESCRIPTION
Solution:
Refactor the NDKContext to hold the global state - this will act as the main parent context. All global state event validations will happen here.

Introduce `stores/ndk.ts`, eliminating the need for calling `connect()` in the onMount hook.