### PR TITLE
problem: oxygen crash when using many relays

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -62,12 +62,14 @@ export const profileRelays = [
 
 export const defaultRelays = [
   "wss://nostr.688.org",
-  //"wss://eden.nostr.land",
-  //"wss://relay.damus.io",
-  // "wss://nos.lol",
-  // "wss://nostr.mom",
-  //"wss://atlas.nostr.land",
+  // "wss://eden.nostr.land",
+  // "wss://relay.damus.io",
+  "wss://nos.lol",
+  "wss://nostr.mom",
+  "wss://atlas.nostr.land",
   // "wss://eden.nostr.land",
   // "wss://nos.lol"
   // 'ws://localhost:8080',
 ];
+
+export const ignoreConsensusEvent = "f61353291a91f61c289aefe479b1314f024ba188df33a94bb66027431a777fbc"


### PR DESCRIPTION
probele is solved by following step:

1. allNostrocketEvent subscription behaviour(this introduce extra time complexity, which can be imporved in the future)
2.  consensusNotes sometimes cannot find request event after step1, this is solved by add mempool.subscription
3. consensus status diverge at No.3 consensus event. this is solved by hard code variable ignore consensus event, but we need to figure out how to solve this once for all. 

@gazhayes i will add this to problem tracker later because i am so hungry now. also please check if my way make sense because i kind of feel it is a relatively big change.