### PR TITLE
Add descendants to suggestions of similar subproblems

### DIFF
--- a/src/components/novoproblems/ProblemView.svelte
+++ b/src/components/novoproblems/ProblemView.svelte
@@ -370,14 +370,23 @@
                       {problem}
                     />
                     {#each problem.FullChildren as [_, child]}
-                      {#if childProblemFilter}{#if child.FullTextSearch(childProblemFilter) > 0.65}
+                      {#if child.Status != "closed"}
+                        {#if childProblemFilter}{#if child.FullTextSearch(childProblemFilter) > 0.65}
                           <ChildProblemTile
-                          searchMatch={child.FullTextSearch(childProblemFilter)}
+                            searchMatch={child.FullTextSearch(childProblemFilter)}
                             problem={child}
-                          />{/if}{:else if child.Status != "closed"}<ChildProblemTile
-                          problem={child}
-                        />{/if}
-                    {/each}
+                          />{/if}
+                          {#each child.getDescendants($consensusTipState) as [_, subproblem]}
+                            {#if subproblem.FullTextSearch(childProblemFilter) > 0.65}
+                              <ChildProblemTile
+                                searchMatch={subproblem.FullTextSearch(childProblemFilter)}
+                                problem={subproblem}
+                            />{/if}
+                          {/each}
+                        {:else}
+                          <ChildProblemTile problem={child} />
+                        {/if}
+                    {/if}{/each}
                   {/if}
 
                   {#if $selectedTab == "discussion"}

--- a/src/components/novoproblems/ProblemView.svelte
+++ b/src/components/novoproblems/ProblemView.svelte
@@ -370,8 +370,7 @@
                       {problem}
                     />
                     {#each problem.FullChildren as [_, child]}
-                      {#if child.Status != "closed"}
-                        {#if childProblemFilter}{#if child.FullTextSearch(childProblemFilter) > 0.65}
+                      {#if childProblemFilter}{#if child.FullTextSearch(childProblemFilter) > 0.65}
                           <ChildProblemTile
                             searchMatch={child.FullTextSearch(childProblemFilter)}
                             problem={child}
@@ -383,9 +382,10 @@
                                 problem={subproblem}
                             />{/if}
                           {/each}
-                        {:else}
-                          <ChildProblemTile problem={child} />
-                        {/if}
+                      {:else}
+                      {#if child.Status != "closed"}
+                        <ChildProblemTile problem={child} />
+                      {/if}
                     {/if}{/each}
                   {/if}
 

--- a/src/lib/stores/nostrocket_state/soft_state/problems.ts
+++ b/src/lib/stores/nostrocket_state/soft_state/problems.ts
@@ -331,6 +331,26 @@ function populateChildren(problem: Problem, state: Nostrocket) {
   }
 }
 
+function getDescendants(problem: Problem, state: Nostrocket): Map<String, Problem> {
+  let descendants = new Map<String, Problem>;
+  let queue = Array.from(problem.FullChildren.keys());
+  while (queue.length > 0) {
+    let child = queue.shift();
+    if (child) {
+      let childProblem = state.Problems.get(child);
+      if (childProblem) {
+        descendants.set(child, childProblem); 
+        for (let [uid, c] of childProblem.FullChildren) {
+          if (!descendants.has(uid)) {
+            queue.push(uid);
+          }
+        }
+      }
+    }
+  }
+  return descendants;
+}
+
 export function hasOpenChildren(problem: Problem, state: Nostrocket): boolean {
   if (!state) {
     state = get(consensusTipState);
@@ -389,3 +409,5 @@ function replayEvents(
     if (returnError) {state.Problems.set(_problem!.UID, _problem!)}
     return returnError
 }
+
+export { getDescendants };

--- a/src/lib/stores/nostrocket_state/types.ts
+++ b/src/lib/stores/nostrocket_state/types.ts
@@ -1,6 +1,7 @@
 import type { NDKEvent, NostrEvent } from "@nostr-dev-kit/ndk";
 import { ignitionPubkey, rootEventID } from "../../../settings";
 import { fuzzy } from 'fast-fuzzy';
+import { getDescendants } from './soft_state/problems';
 
 export class Nostrocket {
   Problems: Map<string, Problem>;
@@ -229,6 +230,9 @@ export class Problem {
       grey: false,
       hidden: false,
     }
+  }
+  getDescendants(state: Nostrocket): Map<String, Problem> {
+    return getDescendants(this, state)
   }
   TotalActivity():number {
     return this.Comments.size + this.EventsInState.length


### PR DESCRIPTION
This PR adds descendants (i.e. all children of children) to the problem state and loops over them to find similar subproblems when creating a new subproblem.

Previously, the similar subproblems were suggested by only looking at children, but it makes more sense to look at all descendants.

https://nostrocket.org/nr/Nostrocket/problems/6e3ffe8f216cf3f69f4a12b077e45f829a867941a52a71e150cf8dfdea3b6129